### PR TITLE
Update rake task to follow strategy depending on the model

### DIFF
--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -2,7 +2,7 @@ namespace :geocode do
   desc "Geocode all objects without coordinates."
   task :all => :environment do
     class_name = ENV['CLASS'] || ENV['class']
-    @sleep_timer = ENV['SLEEP'] || ENV['sleep']
+    sleep_timer = ENV['SLEEP'] || ENV['sleep']
     batch = ENV['BATCH'] || ENV['batch']
     reverse = ENV['REVERSE'] || ENV['reverse']
     raise "Please specify a CLASS (model)" unless class_name
@@ -20,17 +20,18 @@ namespace :geocode do
         geocode_record(obj, reverse?)
       end
     end
+
+    def geocode_record(obj, reverse=false)
+      reverse ? obj.reverse_geocode : obj.geocode
+      obj.save
+      sleep(sleep_timer.to_f) unless sleep_timer.nil?
+    end
+
+    def reverse?
+      reverse.to_s.downcase == 'true'
+    end
   end
   
-  def geocode_record(obj, reverse=false)
-    reverse ? obj.reverse_geocode : obj.geocode
-    obj.save
-    sleep(@sleep_timer.to_f) unless @sleep_timer.nil?
-  end
-
-  def reverse?
-    reverse.to_s.downcase == 'true'
-  end
 end
 
 ##

--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -13,27 +13,29 @@ namespace :geocode do
     scope = reverse? ? klass.not_reverse.geocoded : klass.reverse.geocoded
     if orm == 'mongoid'
       scope.each do |obj|
-        geocode_record(obj, reverse?)
+        GeocodeTask.geocode_record(obj, reverse?)
       end
     elsif orm == 'active_record'
       scope.find_each(batch_size: batch) do |obj|
-        geocode_record(obj, reverse?)
+        GeocodeTask.geocode_record(obj, reverse?)
       end
     end
-
-    def geocode_record(obj, reverse=false)
-      reverse ? obj.reverse_geocode : obj.geocode
-      obj.save
-      sleep(sleep_timer.to_f) unless sleep_timer.nil?
-    end
-
-    def reverse?
-      reverse.to_s.downcase == 'true'
-    end
   end
-  
 end
 
+module GeocodeTask
+  extend self
+
+  def geocode_record(obj, reverse=false)
+    reverse ? obj.reverse_geocode : obj.geocode
+    obj.save
+    sleep(sleep_timer.to_f) unless sleep_timer.nil?
+  end
+
+  def reverse?
+    reverse.to_s.downcase == 'true'
+  end
+end
 ##
 # Get a class object from the string given in the shell environment.
 # Similar to ActiveSupport's +constantize+ method.

--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -9,15 +9,16 @@ namespace :geocode do
     klass = class_from_string(class_name)
     batch = (batch.to_i unless batch.nil?) || 1000
     orm = (klass < Geocoder::Model::Mongoid) ? 'mongoid' : 'active_record'
+    reverse = false unless reverse.to_s.downcase == 'true'
 
-    scope = GeocodeTask.reverse? ? klass.not_reverse.geocoded : klass.reverse.geocoded
+    scope = reverse ? klass.not_reverse.geocoded : klass.reverse.geocoded
     if orm == 'mongoid'
       scope.each do |obj|
-        GeocodeTask.geocode_record(obj, GeocodeTask.reverse?)
+        GeocodeTask.geocode_record(obj, reverse)
       end
     elsif orm == 'active_record'
       scope.find_each(batch_size: batch) do |obj|
-        GeocodeTask.geocode_record(obj, GeocodeTask.reverse?)
+        GeocodeTask.geocode_record(obj, reverse)
       end
     end
   end
@@ -30,10 +31,6 @@ module GeocodeTask
     reverse ? obj.reverse_geocode : obj.geocode
     obj.save
     sleep(sleep_timer.to_f) unless sleep_timer.nil?
-  end
-
-  def reverse?
-    reverse.to_s.downcase == 'true'
   end
 end
 ##

--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -11,7 +11,7 @@ namespace :geocode do
     orm = (klass < Geocoder::Model::Mongoid) ? 'mongoid' : 'active_record'
     reverse = false unless reverse.to_s.downcase == 'true'
 
-    scope = reverse ? klass.not_reverse.geocoded : klass.reverse.geocoded
+    scope = reverse ? klass.not_reverse_geocoded : klass.not_geocoded
     if orm == 'mongoid'
       scope.each do |obj|
         GeocodeTask.geocode_record(obj, reverse)

--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -10,14 +10,14 @@ namespace :geocode do
     batch = (batch.to_i unless batch.nil?) || 1000
     orm = (klass < Geocoder::Model::Mongoid) ? 'mongoid' : 'active_record'
 
-    scope = reverse? ? klass.not_reverse.geocoded : klass.reverse.geocoded
+    scope = GeocodeTask.reverse? ? klass.not_reverse.geocoded : klass.reverse.geocoded
     if orm == 'mongoid'
       scope.each do |obj|
-        GeocodeTask.geocode_record(obj, reverse?)
+        GeocodeTask.geocode_record(obj, GeocodeTask.reverse?)
       end
     elsif orm == 'active_record'
       scope.find_each(batch_size: batch) do |obj|
-        GeocodeTask.geocode_record(obj, reverse?)
+        GeocodeTask.geocode_record(obj, GeocodeTask.reverse?)
       end
     end
   end

--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -8,32 +8,28 @@ namespace :geocode do
     raise "Please specify a CLASS (model)" unless class_name
     klass = class_from_string(class_name)
     batch = (batch.to_i unless batch.nil?) || 1000
-    reverse = false unless reverse.to_s.downcase == 'true'
-    orm = defined?(Geocoder::Model::Mongoid) ? 'mongoid' : 'active_record'
+    orm = (klass < Geocoder::Model::Mongoid) ? 'mongoid' : 'active_record'
 
-    if reverse && orm == 'mongoid'
-      klass.not_reverse_geocoded.each do |obj|
-        geocode_record(obj, reverse: true)
+    scope = reverse? ? klass.not_reverse.geocoded : klass.reverse.geocoded
+    if orm == 'mongoid'
+      scope.each do |obj|
+        geocode_record(obj, reverse?)
       end
-    elsif reverse && orm == 'active_record'
-      klass.not_reverse_geocoded.find_each(batch_size: batch) do |obj|
-        geocode_record(obj, reverse: true)
-      end
-    elsif orm == 'mongoid'
-      klass.not_geocoded.each do |obj|
-        geocode_record(obj)
-      end
-    else
-      klass.not_geocoded.find_each(batch_size: batch) do |obj|
-        geocode_record(obj)
+    elsif orm == 'active_record'
+      scope.find_each(batch_size: batch) do |obj|
+        geocode_record(obj, reverse?)
       end
     end
   end
   
-  def geocode_record(obj, reverse: false)
+  def geocode_record(obj, reverse=false)
     reverse ? obj.reverse_geocode : obj.geocode
     obj.save
     sleep(@sleep_timer.to_f) unless @sleep_timer.nil?
+  end
+
+  def reverse?
+    reverse.to_s.downcase == 'true'
   end
 end
 

--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -1,4 +1,4 @@
-require './lib/geocoder/models/mongoid'
+require "geocoder/models/mongoid" 
 
 namespace :geocode do
   desc "Geocode all objects without coordinates."

--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -14,20 +14,26 @@ namespace :geocode do
     scope = reverse ? klass.not_reverse_geocoded : klass.not_geocoded
     if orm == 'mongoid'
       scope.each do |obj|
-        GeocodeTask.geocode_record(obj, reverse)
+        geocode_record(obj)
       end
     elsif orm == 'active_record'
       scope.find_each(batch_size: batch) do |obj|
-        GeocodeTask.geocode_record(obj, reverse)
+        geocode_record(obj)
       end
     end
+
+    geocode_record = -> (obj) {
+      reverse ? obj.reverse_geocode : obj.geocode
+      obj.save
+      sleep(sleep_timer.to_f) unless sleep_timer.nil?
+    }
   end
 end
 
 module GeocodeTask
   extend self
 
-  def geocode_record(obj, reverse=false)
+  def geocode_record(obj, reverse=false, sleep_timer)
     reverse ? obj.reverse_geocode : obj.geocode
     obj.save
     sleep(sleep_timer.to_f) unless sleep_timer.nil?

--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -1,3 +1,5 @@
+require './lib/geocoder/models/mongoid'
+
 namespace :geocode do
   desc "Geocode all objects without coordinates."
   task :all => :environment do

--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -14,29 +14,19 @@ namespace :geocode do
     scope = reverse ? klass.not_reverse_geocoded : klass.not_geocoded
     if orm == 'mongoid'
       scope.each do |obj|
-        geocode_record(obj)
+        geocode_record.call(obj)
       end
     elsif orm == 'active_record'
       scope.find_each(batch_size: batch) do |obj|
-        geocode_record(obj)
+        geocode_record.call(obj)
       end
     end
 
-    geocode_record = -> (obj) {
+    geocode_record = ->(obj) {
       reverse ? obj.reverse_geocode : obj.geocode
       obj.save
       sleep(sleep_timer.to_f) unless sleep_timer.nil?
     }
-  end
-end
-
-module GeocodeTask
-  extend self
-
-  def geocode_record(obj, reverse=false, sleep_timer)
-    reverse ? obj.reverse_geocode : obj.geocode
-    obj.save
-    sleep(sleep_timer.to_f) unless sleep_timer.nil?
   end
 end
 ##

--- a/lib/tasks/geocoder.rake
+++ b/lib/tasks/geocoder.rake
@@ -11,6 +11,12 @@ namespace :geocode do
     orm = (klass < Geocoder::Model::Mongoid) ? 'mongoid' : 'active_record'
     reverse = false unless reverse.to_s.downcase == 'true'
 
+    geocode_record = lambda { |obj|
+      reverse ? obj.reverse_geocode : obj.geocode
+      obj.save
+      sleep(sleep_timer.to_f) unless sleep_timer.nil?
+    }
+
     scope = reverse ? klass.not_reverse_geocoded : klass.not_geocoded
     if orm == 'mongoid'
       scope.each do |obj|
@@ -22,11 +28,6 @@ namespace :geocode do
       end
     end
 
-    geocode_record = ->(obj) {
-      reverse ? obj.reverse_geocode : obj.geocode
-      obj.save
-      sleep(sleep_timer.to_f) unless sleep_timer.nil?
-    }
   end
 end
 ##


### PR DESCRIPTION
This updates rake geocode:all to only follow the Mongoid strategy if it is specifically defined for that model. In addition, it avoids using keyword parameters that do not work with Ruby 1.9.3 and defines geocode_record as a lambda so that it does not exist in the global scope.